### PR TITLE
Bugfix: correct reference to SVGImage

### DIFF
--- a/the-graph/factories.js
+++ b/the-graph/factories.js
@@ -34,7 +34,7 @@ exports.createPolygon = function(options) {
 };
 
 exports.createImg = function(options) {
-  return TheGraph.SVGImage(options);
+  return SVGImage(options);
 };
 
 exports.createCanvas = function(options) {


### PR DESCRIPTION
exports.createImg did not work as the underlying function was being called with TheGraph.SVGImage, although the import was named as SVGImage.